### PR TITLE
Removing duplicated react-scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
     "prettier": "^2.4.1",
-    "react-scripts": "4.0.3",
     "typescript": "^4.1.2"
   },
   "scripts": {


### PR DESCRIPTION
No arquivo `package.json` foi removido a duplicidade do pacote `react-scripts` 